### PR TITLE
[fix/searchChallenge] 챌린지 검색 시 참여중인 챌린지는 제외하고 보내도록 수정

### DIFF
--- a/src/main/java/ollie/wecare/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/ollie/wecare/challenge/repository/ChallengeRepository.java
@@ -27,4 +27,5 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     Optional<Challenge> findTop1ByOrderByCreatedDateDesc();
     Optional<Challenge> findByChallengeIdxAndStatusEquals(Long challengeIdx, String status);
     List<Challenge> findByParticipantsContaining(User user);
+    List<Challenge> findByParticipantsNotContaining(User user);
 }

--- a/src/main/java/ollie/wecare/challenge/service/ChallengeService.java
+++ b/src/main/java/ollie/wecare/challenge/service/ChallengeService.java
@@ -123,12 +123,11 @@ public class ChallengeService {
     public List<SearchChallengeRes> getChallenges(String searchWord) {
         User user = userService.getUserWithValidation();
         if (searchWord.equals("")) {
-            return challengeRepository.findAll().stream()
+            return challengeRepository.findByParticipantsNotContaining(user).stream()
                     .map(SearchChallengeRes::fromChallenge)
                     .toList();
         } else {
-            List<Challenge> challenges = challengeRepository.findByNameContainingAndParticipantsNotContaining(searchWord, user);
-            return challenges.stream()
+            return challengeRepository.findByNameContainingAndParticipantsNotContaining(searchWord, user).stream()
                     .distinct()
                     .map(SearchChallengeRes::fromChallenge)
                     .toList();


### PR DESCRIPTION
## 📌 이슈 번호

## 📢 의논 사항
